### PR TITLE
Move reference solutions out of browser (issue #18)

### DIFF
--- a/llmgrader/routes/api.py
+++ b/llmgrader/routes/api.py
@@ -553,6 +553,11 @@ class APIController:
                 "validation_alert": getattr(self.grader, 'unit_validation_alert', None),
             })
 
+        STUDENT_EXCLUDED_FIELDS = {"solution", "solution_images", "grading_notes"}
+
+        def _strip_solution_fields(question: dict) -> dict:
+            return {k: v for k, v in question.items() if k not in STUDENT_EXCLUDED_FIELDS}
+
         @bp.get("/unit/<unit_name>")
         def unit(unit_name):
             units = self.grader.units
@@ -561,11 +566,28 @@ class APIController:
                 return jsonify({"error": "Unknown unit"}), 404
 
             u = units[unit_name]   # dict keyed by qtag
+            sanitized = {qtag: _strip_solution_fields(q) for qtag, q in u.items()}
 
             return jsonify({
                 "unit": unit_name,
                 "qtags": list(u.keys()),
-                "items": u
+                "items": sanitized
+            })
+
+        @bp.get("/unit/<unit_name>/<qtag>/solution")
+        @self.require_admin
+        def unit_solution(unit_name, qtag):
+            units = self.grader.units
+            if unit_name not in units:
+                return jsonify({"error": "Unknown unit"}), 404
+            u = units[unit_name]
+            if qtag not in u:
+                return jsonify({"error": "Unknown qtag"}), 404
+            q = u[qtag]
+            return jsonify({
+                "solution": q.get("solution", ""),
+                "solution_images": q.get("solution_images", []),
+                "grading_notes": q.get("grading_notes", ""),
             })
 
         @bp.post("/grade")

--- a/llmgrader/static/js/app.js
+++ b/llmgrader/static/js/app.js
@@ -981,20 +981,22 @@ function buildAdminGradingNotesHtml(question) {
 }
 
 // Admin View: Display selected question with reference solution and grading notes
-// Fixed: Uses q.solution_text (reference solution, not student solution)
-// Fixed: Grading notes formatting preserved via CSS white-space: pre-wrap
 function displayAdminQuestion(unit, qtag) {
-    // Fetch unit data to get question details
-    fetch(`/unit/${unit}`).then(r => r.json()).then(data => {
-        const q = data.items[qtag];
+    Promise.all([
+        fetch(`/unit/${unit}`).then(r => r.json()),
+        fetch(`/unit/${unit}/${qtag}/solution`).then(r => r.json()),
+    ]).then(([unitData, solnData]) => {
+        const q = unitData.items[qtag];
         if (!q) return;
+
+        const fullQ = { ...q, ...solnData };
 
         updateAdminPartialCreditIndicator(q);
 
-        const gradingNotesHtml = buildAdminGradingNotesHtml(q);
+        const gradingNotesHtml = buildAdminGradingNotesHtml(fullQ);
 
         document.getElementById("admin-question-text").innerHTML = q.question_text || "";
-        document.getElementById("admin-solution-text").innerHTML = q.solution || "";
+        document.getElementById("admin-solution-text").innerHTML = fullQ.solution || "";
         document.getElementById("admin-grading-notes").innerHTML = gradingNotesHtml;
 
         // Mirror into mobile panels if on mobile
@@ -1003,7 +1005,7 @@ function displayAdminQuestion(unit, qtag) {
             const ms = document.getElementById("admin-mobile-solution-text");
             const mn = document.getElementById("admin-mobile-grading-notes");
             if (mq) mq.innerHTML = q.question_text || "";
-            if (ms) ms.innerHTML = q.solution || "";
+            if (ms) ms.innerHTML = fullQ.solution || "";
             if (mn) mn.innerHTML = gradingNotesHtml;
         }
 

--- a/tests/services/test_unit_solution_route.py
+++ b/tests/services/test_unit_solution_route.py
@@ -1,0 +1,106 @@
+"""Tests for the /unit/<name> and /unit/<name>/<qtag>/solution routes.
+
+Verifies that reference solution data is stripped from the public endpoint and
+only accessible to admins via the dedicated solution endpoint.
+"""
+
+import pytest
+from pathlib import Path
+
+from llmgrader.app import create_app
+from llmgrader.services.grader import Grader
+
+
+FAKE_UNITS = {
+    "unit1": {
+        "q1": {
+            "qtag": "q1",
+            "question_text": "<p>What is 2+2?</p>",
+            "solution": "<p>The answer is 4.</p>",
+            "solution_images": ["data:image/png;base64,abc123"],
+            "grading_notes": "Award full credit for 4.",
+            "parts": [],
+            "required": True,
+            "partial_credit": False,
+            "tools": [],
+            "rubrics": {},
+            "rubric_total": None,
+            "rubric_groups": [],
+            "preferred_model": None,
+        }
+    }
+}
+
+
+@pytest.fixture()
+def app_with_units(tmp_path: Path, monkeypatch):
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.setenv("LLMGRADER_STORAGE_PATH", str(tmp_path / "storage"))
+    monkeypatch.setenv("LLMGRADER_SECRET_KEY", "test-secret")
+
+    def fake_load_unit_pkg(self):
+        self.units = FAKE_UNITS
+        self.units_order = [{"type": "unit", "name": "unit1"}]
+        self.unit_validation_alert = None
+
+    monkeypatch.setattr(Grader, "load_unit_pkg", fake_load_unit_pkg)
+
+    app = create_app(scratch_dir=str(scratch), soln_pkg=None)
+    app.config["TESTING"] = True
+    return app
+
+
+def test_unit_endpoint_strips_solution_fields(app_with_units):
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/unit1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        q = data["items"]["q1"]
+        assert "solution" not in q
+        assert "solution_images" not in q
+        assert "grading_notes" not in q
+
+
+def test_unit_endpoint_preserves_non_sensitive_fields(app_with_units):
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/unit1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        q = data["items"]["q1"]
+        assert q["question_text"] == "<p>What is 2+2?</p>"
+        assert q["required"] is True
+        assert q["partial_credit"] is False
+        assert q["tools"] == []
+
+
+def test_solution_endpoint_requires_admin(app_with_units, monkeypatch):
+    monkeypatch.setenv("LLMGRADER_AUTH_MODE", "normal")
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/unit1/q1/solution")
+        assert resp.status_code == 403
+
+
+def test_solution_endpoint_returns_data_for_admin(app_with_units, monkeypatch):
+    monkeypatch.setenv("LLMGRADER_AUTH_MODE", "dev-open")
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/unit1/q1/solution")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["solution"] == "<p>The answer is 4.</p>"
+        assert data["solution_images"] == ["data:image/png;base64,abc123"]
+        assert data["grading_notes"] == "Award full credit for 4."
+
+
+def test_solution_endpoint_returns_404_for_unknown_unit(app_with_units, monkeypatch):
+    monkeypatch.setenv("LLMGRADER_AUTH_MODE", "dev-open")
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/nonexistent/q1/solution")
+        assert resp.status_code == 404
+
+
+def test_solution_endpoint_returns_404_for_unknown_qtag(app_with_units, monkeypatch):
+    monkeypatch.setenv("LLMGRADER_AUTH_MODE", "dev-open")
+    with app_with_units.test_client() as client:
+        resp = client.get("/unit/unit1/nonexistent/solution")
+        assert resp.status_code == 404


### PR DESCRIPTION
Strip `solution`, `solution_images`, and `grading_notes` from the public `/unit/<name>` endpoint so students cannot access reference solutions in the browser. Adds an admin-only `/unit/<name>/<qtag>/solution` endpoint for the admin view.

Closes #18

Generated with [Claude Code](https://claude.ai/code)